### PR TITLE
Fix typos in the drag-previews docs

### DIFF
--- a/packages/docs/constellation/05-core-package/00-adapters/00-element/drag-previews.mdx
+++ b/packages/docs/constellation/05-core-package/00-adapters/00-element/drag-previews.mdx
@@ -345,8 +345,8 @@ import { disableNativeDragPreview } from '@atlaskit/pragmatic-drag-and-drop/elem
 
 draggable({
   element: myElement,
-  onGenerateDragPreview({ setNativeDragPreview }) {
-    disableNativeDragPreview({ setNativeDragPreview });
+  onGenerateDragPreview({ nativeSetDragImage }) {
+    disableNativeDragPreview({ nativeSetDragImage });
   },
 });
 ```
@@ -368,8 +368,8 @@ import { disableNativeDragPreview } from '@atlaskit/pragmatic-drag-and-drop/elem
 
 draggable({
   element: myElement,
-  onGenerateDragPreview({ setNativeDragPreview }) {
-    disableNativeDragPreview({ setNativeDragPreview });
+  onGenerateDragPreview({ nativeSetDragImage }) {
+    disableNativeDragPreview({ nativeSetDragImage });
   },
 });
 ```


### PR DESCRIPTION
Some drag preview code snippets use a wrong name for the [`nativeSetDragImage()`](https://github.com/atlassian/pragmatic-drag-and-drop/blob/5ba9ad19d809e66f6ece160965aec4b842b18710/packages/core/src/public-utils/element/disable-native-drag-preview.ts#L34) function and don't work.