### PR TITLE
Fix useEffect syntax error in conditional dragging docs

### DIFF
--- a/packages/documentation/constellation/05-core-package/00-adapters/00-element/about.mdx
+++ b/packages/documentation/constellation/05-core-package/00-adapters/00-element/about.mdx
@@ -159,7 +159,7 @@ function noop(){};
 function Item({isDraggingEnabled}: {isDraggingEnabled: boolean}) {
   const ref = useRef();
 
-  useEffect({
+  useEffect(() => {
     // when disabled, don't make the element draggable
     // this will allow a parent draggable to still be dragged
     if(!isDraggingEnabled) {


### PR DESCRIPTION
Addresses #224

Fixed incorrect `useEffect` syntax in the conditional dragging documentation example.

## Change
```diff
- useEffect({
+ useEffect(() => {
```

## Why
`useEffect` expects a callback function as its first argument, not an object. This was causing confusion for developers copying the example code.

## Testing
- Verified the syntax is now correct
- Example now follows React best practices
<!-- Rovo Dev code review status -->
---
<img src="https://i.imgur.com/MCm0FWH.png" alt="" height="12"> <strong>Rovo Dev couldn't review this pull request</strong>
Upgrade to Rovo Dev Standard to continue using code review.
<!-- /Rovo Dev code review status -->

